### PR TITLE
docs: add app overview and usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,65 @@
-# React + Vite
+# ASL Spaced-Repetition Trainer
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Browser-based American Sign Language practice app that schedules reviews with a simplified SM2 algorithm and uses on-device hand‑pose detection for real‑time feedback.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+- Spaced-repetition system tracks progress and shows signs when they are due.
+- Two modes: **Start Review** for scheduled practice and **Practice** for free exploration.
+- Real-time AI recognition for **I Love You**, **More**, **Help**, and **Stop** using TensorFlow hand-pose models.
+- Manual grading available for all signs; processing runs entirely in the browser.
 
-## Expanding the ESLint configuration
+## Current Limitations
 
-If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
+- Only a small set of signs have AI recognition; others require manual grading.
+- Heuristic approach may mis-detect with poor lighting or off-camera hands.
+- Motion, face, or body context is not yet supported.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+   The app opens at <http://localhost:5173/>.
+
+## Build
+
+- Create a production build:
+  ```bash
+  npm run build
+  ```
+- Preview the built app:
+  ```bash
+  npm run preview
+  ```
+
+## Camera & AI Requirements
+
+- A modern browser with WebGL and webcam support.
+- Grant camera access when prompted; keep hands centered and well lit.
+- AI runs locally in your browser—no video is uploaded.
+
+## Usage
+
+### Start Review
+
+- On the home screen, click **Start Review** to work through signs due today.
+- AI-supported signs are checked automatically; use **Mark Correct** or **Mark Again** to record progress for all signs.
+
+### Practice
+
+- Select any sign from the **All Signs** grid to practice freely.
+- Exit when finished; progress is saved if you mark results.
+
+## Troubleshooting
+
+- **Camera/AI unavailable** – ensure your webcam is connected, allow browser permissions, and close other apps using the camera. The app falls back to manual practice if AI fails.
+- **No signs due** – **Start Review** will be disabled; choose a sign from the grid to practice.
+- **Recognition inconsistent** – improve lighting, keep hands within the frame, or rely on manual grading.
+- **Reset progress** – clear browser storage for key `asl_srs_v1`.
+


### PR DESCRIPTION
## Summary
- rewrite README with ASL spaced-repetition app description, features, and current limitations
- document setup, build, and camera/AI requirements
- add usage instructions and troubleshooting tips for Start Review and Practice modes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: '_' is defined but never used; no-empty)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4e107a58c8325a698aa6df3af8b31