### PR TITLE
feat: load mediapipe hands locally and handle network failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "vite-react-starter",
       "version": "0.0.0",
       "dependencies": {
+        "@mediapipe/hands": "^0.4.1675469240",
         "@tensorflow-models/hand-pose-detection": "^2.0.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1"
@@ -959,8 +960,7 @@
       "version": "0.4.1675469240",
       "resolved": "https://registry.npmjs.org/@mediapipe/hands/-/hands-0.4.1675469240.tgz",
       "integrity": "sha512-GxoZvL1mmhJxFxjuyj7vnC++JIuInGznHBin5c7ZSq/RbcnGyfEcJrkM/bMu5K1Mz/2Ko+vEX6/+wewmEHPrHg==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.32",
@@ -3419,8 +3419,7 @@
     "@mediapipe/hands": {
       "version": "0.4.1675469240",
       "resolved": "https://registry.npmjs.org/@mediapipe/hands/-/hands-0.4.1675469240.tgz",
-      "integrity": "sha512-GxoZvL1mmhJxFxjuyj7vnC++JIuInGznHBin5c7ZSq/RbcnGyfEcJrkM/bMu5K1Mz/2Ko+vEX6/+wewmEHPrHg==",
-      "peer": true
+      "integrity": "sha512-GxoZvL1mmhJxFxjuyj7vnC++JIuInGznHBin5c7ZSq/RbcnGyfEcJrkM/bMu5K1Mz/2Ko+vEX6/+wewmEHPrHg=="
     },
     "@rolldown/pluginutils": {
       "version": "1.0.0-beta.32",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mediapipe/hands": "^0.4.1675469240",
     "@tensorflow-models/hand-pose-detection": "^2.0.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -391,11 +391,17 @@ function useHandsDetector() {
         videoRef.current.srcObject = stream;
         await videoRef.current.play().catch(() => {});
 
+        if (typeof navigator !== 'undefined' && !navigator.onLine) {
+          throw new Error('Network unavailable for hand detector');
+        }
+
         const model = handPoseDetection.SupportedModels.MediaPipeHands;
         const d = await handPoseDetection.createDetector(model, {
           runtime: 'mediapipe',
           modelType: 'lite',
-          solutionPath: 'https://cdn.jsdelivr.net/npm/@mediapipe/hands',
+          solutionPath: import.meta.env.DEV
+            ? '/node_modules/@mediapipe/hands'
+            : '/hands',
         });
         if (stopped) return;
         setDetector(d);
@@ -403,6 +409,7 @@ function useHandsDetector() {
       } catch (e) {
         console.error('Init error', e);
         setErr(e && e.message ? e.message : 'Unknown error');
+        setReady(true); // default to manual practice
         // Keep UI usable without camera/detector
       }
     }


### PR DESCRIPTION
## Summary
- use locally hosted @mediapipe/hands instead of CDN
- fallback to manual practice when hand detector fails and show network errors
- track @mediapipe/hands as a direct dependency

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: 7 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e74057ac83258ccc8f033e63ef31