### PR TITLE
fix missing css tooling

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
-    "vite": "^7.1.2"
+    "vite": "^7.1.2",
+    "tailwindcss": "^3.4.4",
+    "autoprefixer": "^10.4.16"
   }
 }


### PR DESCRIPTION
## Summary
- add tailwindcss and autoprefixer dev dependencies to match PostCSS config

## Testing
- `npm test`
- `npm run build` *(fails: Cannot find module 'tailwindcss')*
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68a519ac6430832599e5946f63ff33f8